### PR TITLE
Fix the vhat bug

### DIFF
--- a/web-app/s3-upload-frontend.html
+++ b/web-app/s3-upload-frontend.html
@@ -68,6 +68,18 @@
         const uploadStatus = document.getElementById('uploadStatus');
         const documentList = document.getElementById('documentList');
 
+        // Authorization helper (uses tokens if present in localStorage)
+        function getAuthHeaders() {
+            try {
+                const token = localStorage.getItem('taxdoc_token') ||
+                              localStorage.getItem('authToken') ||
+                              localStorage.getItem('id_token');
+                return token ? { 'Authorization': `Bearer ${token}` } : {};
+            } catch (e) {
+                return {};
+            }
+        }
+
         uploadArea.addEventListener('dragover', (e) => {
             e.preventDefault();
             uploadArea.classList.add('dragover');
@@ -100,7 +112,11 @@
                 showStatus('Getting upload URL...', 'processing');
                 
                 // Step 1: Get presigned URL
-                const urlResponse = await fetch(`${API_BASE}/upload-url?filename=${encodeURIComponent(file.name)}&contentType=${encodeURIComponent(file.type)}`);
+                const urlResponse = await fetch(`${API_BASE}/upload-url?filename=${encodeURIComponent(file.name)}&contentType=${encodeURIComponent(file.type)}`, {
+                    headers: { 
+                        ...getAuthHeaders()
+                    }
+                });
                 
                 if (!urlResponse.ok) {
                     throw new Error(`Failed to get upload URL: ${urlResponse.status}`);
@@ -129,7 +145,8 @@
                 const processResponse = await fetch(`${API_BASE}/process`, {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        ...getAuthHeaders()
                     },
                     body: JSON.stringify({
                         s3Key: key,


### PR DESCRIPTION
Add Authorization headers to presign and document processing requests to fix 401 errors for authenticated users.

---
<a href="https://cursor.com/background-agent?bcId=bc-8be777f9-eadb-4b8d-a267-1191f58c55c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8be777f9-eadb-4b8d-a267-1191f58c55c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

